### PR TITLE
Do not try to deduplicate zombies in the reaper process

### DIFF
--- a/src/consuela_zombie_reaper.erl
+++ b/src/consuela_zombie_reaper.erl
@@ -7,7 +7,6 @@
 %% api
 
 -type registry() :: consuela_registry:t().
--type name()     :: consuela_registry:name().
 
 -export([start_link/2]).
 
@@ -84,7 +83,6 @@ drain(Ref) ->
 -type zombie() :: consuela_registry:reg().
 
 -type st() :: #{
-    zombies        := #{name() => _},
     queue          := queue:queue(zombie()),
     registry       := consuela_registry:t(),
     retry_strategy := genlib_retry:strategy(),


### PR DESCRIPTION
As long as we do not know for sure which registration failed or succeeded we have no right to discard subsequent enqueue requests otherwise some dead registration can become stuck until the whole node is dead.