### PR TITLE
Check PIDs for liveness where applicable

### DIFF
--- a/src/consuela_lock.erl
+++ b/src/consuela_lock.erl
@@ -72,13 +72,15 @@ release(ID, Session, Client) ->
     end.
 
 -spec delete(lock(), consuela_client:t()) ->
-    ok | {error, failed}.
+    ok | {error, stale}.
 
 delete(#{id := ID, indexes := {_, ModifyIndex, _}}, Client) ->
     Resource = {[<<"/v1/kv/">> | encode_id(ID)], encode_cas(ModifyIndex)},
     case consuela_client:request(delete, Resource, Client) of
         {ok, true} ->
             ok;
+        {ok, false} ->
+            {error, stale};
         {error, Reason} ->
             erlang:error(Reason)
     end.

--- a/src/consuela_registry.erl
+++ b/src/consuela_registry.erl
@@ -53,7 +53,7 @@ new(Namespace, Session, Client) ->
     {done, ok | {error, exists}} | {failed, failure()}.
 
 -spec try_unregister(reg(), t()) ->
-    {done, ok} | {failed, failure()}.
+    {done, ok | {error, stale}} | {failed, failure()}.
 
 -spec lookup(name(), t()) ->
     {done, {ok, pid()} | {error, notfound}} | {failed, failure()}.
@@ -78,8 +78,7 @@ try_unregister({Rid, Name, Pid}, Registry = #{session := #{id := Sid}, client :=
         case consuela_lock:get(ID, Client) of
             {ok, Lock = #{value := {Rid, Pid}, session := Sid}} ->
                 % Looks like the lock is still ours
-                ok = consuela_lock:delete(Lock, Client),
-                {done, ok};
+                {done, consuela_lock:delete(Lock, Client)};
             {ok, #{value := _, session := _}} ->
                 % Looks like someone (even us) is quick enough to hold it already, as the result of client
                 % retrying for example

--- a/src/consuela_registry_server.erl
+++ b/src/consuela_registry_server.erl
@@ -374,13 +374,19 @@ lookup(Ref, Name, Registry) ->
         {error, notfound} ->
             case consuela_registry:lookup(Name, Registry) of
                 {done, {ok, Pid}} ->
-                    {done, ensure_alive(Pid)};
+                    % Process may be alive from the global point of view but already dead from the
+                    % local point of view. In the latter case the registration should be queued in
+                    % the zombie reaper already. Since local liveness check is cheap we perform it
+                    % here. This is a kind of safeguard for scenarios where one tries to register
+                    % process under the name of a process that just died but have not been reaped
+                    % yet.
+                    {done, ensure_alive_if_local(Pid)};
                 Result ->
                     Result
             end
     end.
 
-ensure_alive(Pid) ->
+ensure_alive_if_local(Pid) ->
     This = erlang:node(),
     case erlang:node(Pid) of
         This ->

--- a/src/consuela_zombie_reaper.erl
+++ b/src/consuela_zombie_reaper.erl
@@ -74,19 +74,11 @@ start_link(Registry, Opts) ->
 enqueue(Ref, Zombie) ->
     enqueue(Ref, Zombie, #{}).
 
--type notification() :: {pid(), _Message}.
-
--type enqueue_opts() :: #{
-    drain => boolean(),
-    notify => notification()
-}.
-
--spec enqueue(ref(), zombie(), enqueue_opts()) ->
+-spec enqueue(ref(), zombie(), #{drain => boolean()}) ->
     ok.
 
 enqueue(Ref, Zombie, Opts) ->
-    Notification = maps:get(notify, Opts, undefined),
-    gen_server:cast(Ref, {enqueue, Zombie, Notification, Opts}).
+    gen_server:cast(Ref, {enqueue, Zombie, Opts}).
 
 -spec drain(ref()) ->
     ok.
@@ -99,7 +91,7 @@ drain(Ref) ->
 -type zombie() :: consuela_registry:reg().
 
 -type st() :: #{
-    queue          := queue:queue({zombie(), notification() | undefined}),
+    queue          := queue:queue(zombie()),
     registry       := consuela_registry:t(),
     retry_strategy := genlib_retry:strategy(),
     retry_state    => genlib_retry:strategy(),
@@ -140,15 +132,13 @@ handle_call(Call, From, St) ->
     _ = beat({unexpected, {{call, From}, Call}}, St),
     {noreply, St}.
 
--type cast() ::
-    {enqueue, zombie(), notification() | undefined, enqueue_opts()} |
-    drain.
+-type cast() :: {enqueue, zombie()} | drain.
 
 -spec handle_cast(cast(), st()) ->
     {noreply, st()}.
 
-handle_cast({enqueue, Zombie, Notification, Opts}, St) ->
-    {noreply, handle_enqueue(Zombie, Notification, Opts, St)};
+handle_cast({enqueue, Zombie, Opts}, St) ->
+    {noreply, handle_enqueue(Zombie, Opts, St)};
 handle_cast(drain, St) ->
     {noreply, try_drain_queue(St)};
 handle_cast(Cast, St) ->
@@ -181,8 +171,8 @@ code_change(_Vsn, St, _Extra) ->
 
 %%
 
-handle_enqueue(Zombie, Notification, Opts, St0 = #{queue := Q}) ->
-    St1 = St0#{queue := queue:in({Zombie, Notification}, Q)},
+handle_enqueue(Zombie, Opts, St0 = #{queue := Q}) ->
+    St1 = St0#{queue := queue:in(Zombie, Q)},
     _ = beat({{zombie, Zombie}, enqueued}, St1),
     case Opts of
         #{drain := true} ->
@@ -200,12 +190,11 @@ try_drain_queue(St = #{queue := Queue}) ->
     end.
 
 try_clean_queue(Mode, St0 = #{queue := Q0, registry := Registry}) ->
-    {{value, {Zombie, Notification}}, Q1} = queue:out(Q0),
+    {{value, Zombie}, Q1} = queue:out(Q0),
     case consuela_registry:try_unregister(Zombie, Registry) of
         {done, ok} ->
             St1 = St0#{queue := Q1},
             _ = beat({{zombie, Zombie}, {reaping, succeeded}}, St1),
-            _ = try_notify(Notification),
             try_force_timer(reset_retry_state(St1));
         {failed, Reason} ->
             _ = beat({{zombie, Zombie}, {reaping, {failed, Reason}}}, St0),
@@ -216,11 +205,6 @@ try_clean_queue(Mode, St0 = #{queue := Q0, registry := Registry}) ->
                     try_start_timer(St0)
             end
     end.
-
-try_notify(undefined) ->
-    ok;
-try_notify({Pid, Message}) ->
-    Pid ! Message.
 
 try_force_timer(St) ->
     try_start_timer(0, try_reset_timer(St)).

--- a/test/otp_registry_SUITE.erl
+++ b/test/otp_registry_SUITE.erl
@@ -6,10 +6,12 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
+-type group_name() :: atom().
 -type test_name()  :: atom().
 -type config()     :: [{atom(), _}].
 
 -export([all/0]).
+-export([groups/0]).
 -export([init_per_suite/1]).
 -export([end_per_suite/1]).
 
@@ -37,15 +39,24 @@
 %% Description
 
 -spec all() ->
-    [test_name()].
+    [{group, group_name(), list()} | test_name()].
 
 all() ->
     [
         nonexistent_gives_noproc,
         start_stop_works,
         conflict_gives_already_started,
-        instant_reregister_succeeds,
-        instant_reregister_succeeds
+
+        {group, instant_reregister, [{repeat, 10}]}
+
+    ].
+
+-spec groups() ->
+    [{group_name(), list(), [test_name()]}].
+
+groups() ->
+    [
+        {instant_reregister, [], [instant_reregister_succeeds]}
     ].
 
 %% Startup / shutdown

--- a/test/otp_registry_SUITE.erl
+++ b/test/otp_registry_SUITE.erl
@@ -115,7 +115,7 @@ instant_reregister_succeeds(_C) ->
     Ref = mk_ref(mooself),
     ?assertMatch({ok, _}, gen_server:start(Ref, ?MODULE, undefined, [])),
     ?assertEqual(stopped, gen_server:call(Ref, stop)),
-    ok = timer:sleep(1), % strictly less than typical Consul request latenc
+    ok = timer:sleep(1), % strictly less than typical Consul request latency
     ?assertMatch({ok, _}, gen_server:start(Ref, ?MODULE, undefined, [])),
     ?assertEqual(stopped, gen_server:call(Ref, stop)).
 


### PR DESCRIPTION
Strangely enough this allows to reregister processes under the same name in quick succession.