### PR TITLE
Make presence and discovery saner

### DIFF
--- a/src/consuela_client.erl
+++ b/src/consuela_client.erl
@@ -143,8 +143,8 @@ request(Method, Resource, Content, C) ->
     case issue_request(Request, C) of
         {ok, Status, _Headers, RespBody} when Status >= 200, Status < 300 ->
             decode_response(RespBody);
-        {ok, Status, _Headers, _RespBody} when Status >= 400, Status < 500 ->
-            {error, get_client_error(Status)};
+        {ok, Status, _Headers, RespBody} when Status >= 400, Status < 500 ->
+            {error, get_client_error(Status, RespBody)};
         {ok, Status, _Headers, RespBody} when Status >= 500, Status < 600 ->
             {error, {
                 get_server_error_class(Status),
@@ -189,11 +189,11 @@ issue_request(Request = {Method, Url, Headers, Body}, C = #{opts := TransOpts}) 
     _ = beat({result, Result}, C),
     Result.
 
-get_client_error(401) ->
+get_client_error(401, _) ->
     unauthorized;
-get_client_error(403) ->
+get_client_error(403, _) ->
     forbidden;
-get_client_error(404) ->
+get_client_error(404, _) ->
     notfound.
 
 get_server_error_class(Code) when

--- a/src/consuela_health.erl
+++ b/src/consuela_health.erl
@@ -55,6 +55,7 @@
 -export_type([check_id/0]).
 -export_type([node_name/0]).
 -export_type([tag/0]).
+-export_type([metadata/0]).
 -export_type([endpoint/0]).
 -export_type([status/0]).
 -export_type([t/0]).
@@ -87,6 +88,7 @@ get(ServiceName, Tags, Passing, Client) ->
     name     := service_name(),
     id       => service_id(),
     tags     := [tag()],
+    metadata => metadata(),
     endpoint => endpoint(),
     checks   => [check_params()]
 }.
@@ -151,7 +153,8 @@ encode_service_params(#{
         },
         [
             encode_endpoint(maps:get(endpoint, V, undefined)),
-            encode_checks(maps:get(checks, V, undefined))
+            encode_checks(maps:get(checks, V, undefined)),
+            encode_metadata(maps:get(metadata, V, #{}))
         ]
     ).
 
@@ -179,6 +182,9 @@ encode_address(V) ->
 
 encode_port(V) ->
     encode_integer(V).
+
+encode_metadata(V) when is_map(V) ->
+    #{<<"Meta">> => V}.
 
 encode_checks(undefined) ->
     #{};

--- a/src/consuela_presence_session.erl
+++ b/src/consuela_presence_session.erl
@@ -13,12 +13,19 @@
 
 -type seconds() :: non_neg_integer().
 
+-type service() :: #{
+    id       := consuela_health:service_id(),
+    name     := name(),
+    address  := inet:ip_address(),
+    tags     => [consuela_health:tag()]
+}.
+
 -type opts() :: #{
     interval => seconds(), % 5 by default
     pulse    => {module(), _PulseOpts}
 }.
 
--export([start_link/5]).
+-export([start_link/4]).
 -export([get_check_id/1]).
 
 -export_type([name/0]).
@@ -49,11 +56,19 @@
 
 %%
 
--spec start_link(name(), inet:ip_address(), consuela_presence_server:ref(), client(), opts()) ->
+%% Only alphanumeric sequences with dashes and underscores allowed for metadata
+%% keys.
+%% See: https://github.com/hashicorp/consul/blob/v1.5.3/agent/structs/structs.go#L104
+
+-define(MD_NODENAME, <<"consuela-erlang-nodename">>).
+
+%%
+
+-spec start_link(service(), consuela_presence_server:ref(), client(), opts()) ->
     {ok, pid()} | {error, _}.
 
-start_link(Name, Address, ServerRef, Client, Opts) ->
-    St = mk_state(Name, Address, ServerRef, Client, Opts),
+start_link(Service = #{name := Name}, ServerRef, Client, Opts) ->
+    St = mk_state(Service, ServerRef, Client, Opts),
     gen_server:start_link({local, mk_local_ref(Name)}, ?MODULE, St, []).
 
 -spec get_check_id(name()) ->
@@ -71,10 +86,11 @@ mk_local_ref(Name) ->
 %%
 
 -type st() :: #{
+    id       := consuela_health:service_id(),
     name     := name(),
     address  := inet:ip_address(),
     server   := consuela_health:endpoint(),
-    check_id := consuela_health:check_id(),
+    tags     => [consuela_health:tag()],
     interval := non_neg_integer(),
     client   := client(),
     pulse    := {module(), _PulseOpts}
@@ -82,16 +98,13 @@ mk_local_ref(Name) ->
 
 -type from() :: {pid(), reference()}.
 
--spec mk_state(name(), inet:ip_address(), consuela_presence_server:ref(), client(), opts()) ->
+-spec mk_state(service(), consuela_presence_server:ref(), client(), opts()) ->
     st().
 
-mk_state(Name, Address, ServerRef, Client, Opts) ->
+mk_state(Service, ServerRef, Client, Opts) ->
     {ok, Endpoint} = consuela_presence_server:get_endpoint(ServerRef),
-    #{
-        name     => Name,
-        address  => Address,
+    Service#{
         server   => Endpoint,
-        check_id => <<Name/binary, ":presence:tcp">>,
         interval => maps:get(interval, Opts, 5),
         client   => Client,
         pulse    => maps:get(pulse, Opts, {?MODULE, []})
@@ -109,8 +122,8 @@ init(St = #{name := Name}) ->
 -spec handle_call(_Call, from(), st()) ->
     {reply, _, st(), hibernate} | {noreply, st(), hibernate}.
 
-handle_call(get_check_id, _From, St = #{check_id := CheckID}) ->
-    {reply, CheckID, St, hibernate};
+handle_call(get_check_id, _From, St = #{id := ServiceID}) ->
+    {reply, mk_check_name(ServiceID), St, hibernate};
 handle_call(Call, From, St) ->
     _ = beat({unexpected, {{call, From}, Call}}, St),
     {noreply, St, hibernate}.
@@ -143,22 +156,26 @@ terminate(Reason, St = #{name := Name}) ->
 code_change(_Vsn, St, _Extra) ->
     {ok, St}.
 
-register_service(#{
+register_service(St = #{
+    id := ServiceID,
     name := Name,
     address := Address,
-    check_id := CheckID,
     server := {_, Port},
     interval := Interval,
     client := Client
 }) ->
     ServiceParams = #{
+        id       => ServiceID,
         name     => Name,
         endpoint => {Address, 0},
-        tags     => [], % TODO
+        tags     => maps:get(tags, St, []),
+        metadata => #{
+            ?MD_NODENAME => encode_node(erlang:node())
+        },
         checks   => [
             #{
-                id      => CheckID,
-                name    => CheckID,
+                id      => mk_check_name(ServiceID),
+                name    => mk_check_name(Name),
                 type    => {tcp, {Address, Port}, Interval},
                 initial => passing % So we would be able to start discovery right away
                 % TODO
@@ -169,9 +186,20 @@ register_service(#{
     ok = consuela_health:register(ServiceParams, Client),
     ok.
 
-deregister_service(#{name := Name, client := Client}) ->
-    ok = consuela_health:deregister(Name, Client),
+deregister_service(#{id := ServiceID, client := Client}) ->
+    ok = consuela_health:deregister(ServiceID, Client),
     ok.
+
+mk_check_name(Name) ->
+    <<Name/binary, ":presence:tcp">>.
+
+encode_node(V) ->
+    erlang:atom_to_binary(V, latin1).
+
+decode_node(V) ->
+    % TODO
+    % Potentially unsafe.
+    erlang:binary_to_atom(V, latin1).
 
 %%
 


### PR DESCRIPTION
* Make less assumptions about environment.
* Store Erlang VM nodename in service metadata for more predictable discovery.
* Allow to specify service tags upon registration.
* Refrain from hardcoding registration service ids, abuse hostnames by default for uniqueness.
